### PR TITLE
[tvOS] configure.ac more robust found_sdk_version

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -323,15 +323,18 @@ case $host in
 
         # If tvOS
         if test "$use_platform" = "tvos"; then
+          platform_os="tvos"
           # setup which cpu to use
           if test "x$use_cpu" = "xauto"; then
             use_cpu=arm64
+            target_platform=appletvos
+          elif test "x$use_cpu" = "arm64"; then
+            target_platform=appletvos
+          else
+            AC_MSG_ERROR(error in configure of --with-cpu=$use_cpu)
           fi
-
-          target_platform=appletvos
-          platform_os="tvos"
-
-          found_sdk_version=[`$use_xcodebuild -showsdks | grep $target_platform | sort | tail -n 1 | awk '{ print $2}'`]
+          
+          found_sdk_version=[`$use_xcodebuild -showsdks | sed -E -n 's/.*'"$target_platform"'([0-9]+)\.([0-9]+)/\1.\2/p' | sort  -n -t. -k1,1 -k2,2 | tail -n 1`]
           use_sdk="${use_sdk:-$found_sdk_version}"
           platform_cflags+=" -fembed-bitcode"
           platform_cxxflags+=" -fembed-bitcode"


### PR DESCRIPTION
## Description
Use sed to better find the SDK number from xcodebuild -showsdks

## Motivation and Context
Ive started exploring adding a target for the tvOS simulator. as part of that, ive found that finding the sdk when not supplied via the configure command could be a little more generic rather than the existing grep.
Also adds a fallback error if an incorrect CPU architecture (non arm64) is provided in the configure, rather than continuing.

An example of where im headed can be seen in the following commit
https://github.com/fuzzard/xbmc/commit/a93601e94608bf67995c413f5148609c8e267ac7

## How Has This Been Tested?
Depends build still works as expected.

