### PR TITLE
[depends] Binary-addon make clean target

### DIFF
--- a/tools/depends/target/binary-addons/Makefile
+++ b/tools/depends/target/binary-addons/Makefile
@@ -4,3 +4,10 @@ ADDON_SRC_PREFIX :=
 
 -include ../../Makefile.include
 include ../../xbmc-addons.include
+
+clean:
+	$(MAKE) -C $(PLATFORM) clean
+	rm -f .installed-$(PLATFORM)
+
+distclean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)


### PR DESCRIPTION
## Description
Provides a clean target for binary addons

## Motivation and Context
https://github.com/SylvainCecchetto/xbmc/issues/27#issuecomment-483425267

## How Has This Been Tested?
Create single/multiple binary addons and then run clean:

make -j4 -C tools/depends/target/binary-addons ADDONS="pvr.*"
make -C tools/depends/target/binary-addons clean

Note:
This does NOT clear out /addons/*addonname* from kodi, only clears out the build folders

clean just makes it possible to build again, distclean clears out all cached build files.



